### PR TITLE
build binary on travis and --version flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,31 @@
 language: crystal
+os:
+  - linux
+  - osx
+
+install: |
+  if [ $TRAVIS_OS_NAME = "linux" ]
+  then
+    docker build --tag batch .
+  fi
+
 script:
-- make build
-- make test
+  - make build
+  # https://github.com/crystal-lang/crystal/issues/8075
+  # - make test
+  - |
+    if [ $TRAVIS_OS_NAME = "linux" ]
+    then
+      rm -f bin/batch && docker run --rm --mount "type=bind,source=$PWD,destination=/app" batch
+    fi
+  - tar -C bin -czf batch-$TRAVIS_TAG-x86_64-$TRAVIS_OS_NAME.tar.gz batch
+
+deploy:
+  provider: releases
+  api_key: $GH_TOKEN
+  file_glob: true
+  file: 
+    - batch-*.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:edge
+RUN apk add --update crystal shards libc-dev upx
+WORKDIR /app
+CMD shards build --release --static --no-debug && \
+  strip --strip-all bin/batch && upx --best bin/batch

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ make build # Build bin/batch
 make install # Install bin/batch and scripts into ~/.local/bin
 ```
 
+You can download [binary release](https://github.com/alexherbo2/batch/releases) for your OS.
+
 ## Usage
 
 ``` sh
@@ -121,6 +123,9 @@ alias rl=batch_relink
 
 --no-confirm
   Do not ask for confirmation.
+
+--version / -v
+  Display version number and quit
 
 --help / -h
   Display a help message and quit.

--- a/src/batch.cr
+++ b/src/batch.cr
@@ -18,6 +18,10 @@ struct Command
   end
 end
 
+macro version
+  {{ `git describe --tags --always`.stringify }}
+end
+
 def main
   options = Options.new
   OptionParser.parse! do |parser|
@@ -27,6 +31,7 @@ def main
     parser.on("-d COMMAND", "--drop=COMMAND", "Run command on deleted elements") { |command| options.drop = command }
     parser.on("--editor=COMMAND", %(Configure editor.  If command contains spaces, command must include "${@}" (including the quotes) to receive the argument list.)) { |command| options.editor = command }
     parser.on("--no-confirm", "Do not ask for confirmation") { options.confirm = false }
+    parser.on("-v", "--version", "Display version number and quit") { puts version; exit }
     parser.on("-h", "--help", "Display a help message and quit") { puts parser; exit }
     parser.invalid_option do |flag|
       STDERR.puts "Error: Unknown option: #{flag}"


### PR DESCRIPTION
Closes: #3 

I added `-v` `--version` flag that shows git tag or commit hash of given build

---

To make use of it you would have to:
- activate this your repository on Travis
- generate private GitHub access token (with repo write rights) and add it in Travis (Repo > Settings > Environment Variables ) as GH_TOKEN
- create new tag (example `v1.0.0`) and push it to the repo

Travis will build and deploy binary. It looks like this on my fork:

https://travis-ci.org/TeddyDD/batch/builds/593072997
https://github.com/TeddyDD/batch/releases

---

Test are disabled for now, we can try to enable them after https://github.com/crystal-lang/crystal/issues/8075 is fixed.